### PR TITLE
redesign: Modernize the storefront UI

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,91 +1,200 @@
-
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
+:root {
+  --bg: #f6f7fb;
+  --surface: #ffffff;
+  --text: #1c1830;
+  --muted: #6b6786;
+  --accent: #6c5fc7;
+  --accent-dark: #584bb3;
+  --border: #e7e7f0;
+  --shadow: 0 4px 20px rgba(28, 24, 48, 0.08);
 }
 
+* {
+  box-sizing: border-box;
+}
 
-.page-container {
-  background-color: #282c34;
+.app {
   min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+}
+
+/* Navbar */
+.navbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--border);
+}
+
+.navbar-inner {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 16px 24px;
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.brand {
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.nav-links a {
+  margin-left: 24px;
+  color: var(--muted);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.nav-links a:hover {
+  color: var(--text);
+}
+
+/* Hero */
+.hero {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 72px 24px 48px;
+  text-align: center;
+}
+
+.hero h1 {
+  font-size: clamp(32px, 5vw, 52px);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  margin: 0 0 16px;
+}
+
+.hero-tagline {
+  font-size: 18px;
+  font-style: italic;
+  color: var(--muted);
+  margin: 0;
+}
+
+/* Products */
+.products {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 24px 24px 96px;
+}
+
+.section-title {
+  font-size: 24px;
+  margin: 0 0 24px;
+}
+
+.product-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 24px;
+}
+
+.product-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 28px 24px;
+  text-align: center;
+  box-shadow: var(--shadow);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.product-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 10px 30px rgba(28, 24, 48, 0.12);
+}
+
+.product-thumb {
+  font-size: 56px;
+  line-height: 1;
+  margin-bottom: 16px;
+}
+
+.product-name {
+  font-size: 18px;
+  margin: 0 0 20px;
+}
+
+/* Button */
+.btn {
+  border: none;
+  border-radius: 10px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 15px;
+  font-weight: 600;
+  padding: 10px 20px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.btn:hover {
+  background: var(--accent-dark);
+}
+
+/* Modal */
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
   align-items: center;
   justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-  padding: 0 20px 0 20px;
+  padding: 24px;
+  background: rgba(20, 16, 40, 0.55);
 }
 
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-.btn-container {
-  display: flex;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  text-align: center;
-}
-
-.btn-parent {
-  flex: 1 1 160px;
-}
-
-.btn {
-  
-  margin: 20px;
-  height: 45px;
-  width: 167px !important;
-  font-size: 20px;
-  font-weight: bold;
-  text-align: center;
-  border-radius: 10px;
-  background-color: darkslateblue;
-  color: white;
-  cursor: pointer;
-}
-
-.modal {
-  height: 500px;
-  width: 70%;
-  background-color: grey;
-  border-radius: 30px;
-  position: fixed;
-  top: 20%;
-  text-align: center;
-}
-
-.hidden {
+.modal.hidden {
   display: none;
+}
+
+.modal-content {
+  position: relative;
+  width: 100%;
+  max-width: 420px;
+  padding: 32px;
+  text-align: center;
+  background: var(--surface);
+  border-radius: 20px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
 }
 
 .modal-exit {
   position: absolute;
-  top: 0%;
-  left: 96%;
-  font-weight: bolder;
-  margin-top: 10px;
-  color: white;
-  font-size: 24px;
+  top: 12px;
+  right: 16px;
+  border: none;
+  background: transparent;
+  font-size: 28px;
+  line-height: 1;
+  color: var(--muted);
   cursor: pointer;
 }
 
-.modal img {
-  width: 260px;
-}
-.modal-description {
-font-size: 20px;
-padding-left: 80px;
-padding-right: 80px;
+.modal-exit:hover {
+  color: var(--text);
 }
 
+.modal-img {
+  width: 220px;
+  max-width: 100%;
+  height: auto;
+  border-radius: 12px;
+  margin-bottom: 20px;
+}
+
+.modal-content h2 {
+  margin: 0 0 12px;
+}
+
+.modal-description {
+  font-size: 16px;
+  line-height: 1.5;
+  color: var(--muted);
+  margin: 0;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import shoppingPic from "./img/shopping.png";
 import "./App.css";
 
 // URL of the companion Express backend. Override with VITE_BACKEND_URL in a
@@ -41,51 +40,80 @@ function App() {
   }
 
   return (
-    <div className="App">
-      <header className="App-header"></header>
-      <div className="page-container">
-        <h1>This is your one-stop shop!</h1>
-        <img src={shoppingPic} className="App-logo" alt="logo" />
-        <p>Click on an item to learn more about our products</p>
-        <div className="btn-container">
-          <div className="btn-parent">
-            <button
-              className="btn"
-              onClick={() => getProduct("kitten-mittens")}
-            >
-              Kitten Mittens
-            </button>
-          </div>
-          <div className="btn-parent">
-            <button className="btn" onClick={() => getProduct("doggles")}>
-              Doggles
-            </button>
-          </div>
-          <div className="btn-parent">
-            <button className="btn" onClick={() => getProduct("clown-shoes")}>
-              Clown Shoes
-            </button>
-          </div>
-          <div className="btn-parent">
-            <button className="btn" onClick={() => getProduct("nonfat-water")}>
-              Nonfat Water
-            </button>
-          </div>
+    <div className="app">
+      <header className="navbar">
+        <div className="navbar-inner">
+          <span className="brand">🛍️ One-Stop Shop</span>
+          <nav className="nav-links">
+            <a href="#products">Products</a>
+            <a href="#about">About</a>
+          </nav>
         </div>
+      </header>
 
-        <p>"If we don't have it, you don't need it."</p>
-
-        <div className="modal hidden">
-          <p className={"modal-exit"} onClick={toggleModal}>
-            X
+      <main>
+        <section className="hero">
+          <h1>Everything you need. Nothing you don't.</h1>
+          <p className="hero-tagline">
+            "If we don't have it, you don't need it."
           </p>
+        </section>
+
+        <section id="products" className="products">
+          <h2 className="section-title">Featured Products</h2>
+          <div className="product-grid">
+            <article className="product-card">
+              <div className="product-thumb">🧤</div>
+              <h3 className="product-name">Kitten Mittens</h3>
+              <button
+                className="btn"
+                onClick={() => getProduct("kitten-mittens")}
+              >
+                View details
+              </button>
+            </article>
+            <article className="product-card">
+              <div className="product-thumb">🕶️</div>
+              <h3 className="product-name">Doggles</h3>
+              <button className="btn" onClick={() => getProduct("doggles")}>
+                View details
+              </button>
+            </article>
+            <article className="product-card">
+              <div className="product-thumb">🤡</div>
+              <h3 className="product-name">Clown Shoes</h3>
+              <button className="btn" onClick={() => getProduct("clown-shoes")}>
+                View details
+              </button>
+            </article>
+            <article className="product-card">
+              <div className="product-thumb">💧</div>
+              <h3 className="product-name">Nonfat Water</h3>
+              <button className="btn" onClick={() => getProduct("nonfat-water")}>
+                View details
+              </button>
+            </article>
+          </div>
+        </section>
+      </main>
+
+      <div className="modal hidden">
+        <div className="modal-content">
+          <button
+            className="modal-exit"
+            onClick={toggleModal}
+            aria-label="Close"
+          >
+            ×
+          </button>
           {data ? (
             <>
-              <h2>{data.title}</h2>
               <img
+                className="modal-img"
                 src={`${BACKEND_URL}/${data.imgPath}`}
-                alt="item-image"
+                alt={data.title}
               />
+              <h2>{data.title}</h2>
               <p className="modal-description">{data.description}</p>
             </>
           ) : (


### PR DESCRIPTION
## What

Modernize the sample app's look for the consolidated getting-started tutorial. The old UI was the default Create React App dark theme with plain buttons; this makes it look like a real (if silly) storefront.

## Changes

- Light theme with a Sentry-purple accent, replacing the dark `#282c34` default
- Sticky nav bar with brand + links
- Hero section with headline and tagline
- Responsive product-card grid — emoji thumbnails, rounded cards, hover lift
- Backdrop modal showing the product image, title, and description

## Unchanged (so the tutorial still works)

- `getProduct(slug)`, the `.modal`/`.hidden` toggle, and the `VITE_BACKEND_URL` image fetch
- All four product slugs and their `onClick` handlers, including the `nonfat-water` button the tutorial has you edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)