### PR TITLE
chore: Gitignore .env.sentry-build-plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build
 .env
 .env.local
 .env.*.local
+.env.sentry-build-plugin
 
 # Logs
 npm-debug.log*


### PR DESCRIPTION
Adds `.env.sentry-build-plugin` to `.gitignore`. The getting-started tutorial has readers store their Sentry auth token in this file (the one `@sentry/vite-plugin` auto-loads), so it must never be committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)